### PR TITLE
Implemented proper maven publishing as a substitute to jitpack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -459,6 +459,12 @@ artifacts {
         archives apiJar
     }
 }
+// NODELETE
+// This is used for invoking the publishing script. We cannot use addon.gradle,
+// as it is included too early in the buildscript. We need this below artifacts{}
+if(file("publishing.gradle").exists()) {
+    apply from: "publishing.gradle"
+}
 
 // Updating
 task updateBuildScript {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,22 @@ modGroup = gregtech
 # The build script relies on git to provide a version via tags. It is super easy and will enable you to always know the
 # code base or your binary. Check out this tutorial: https://blog.mattclemente.com/2017/10/13/versioning-with-git-tags/
 
+#
+# Publishing settings
+#
+
+# The server to upload the artifacts to
+repositoryURL = https://gtmega.falsepattern.com/
+
+# What name is the login information inside ~/.m2/settings.xml stored under
+# (see https://gist.github.com/FalsePattern/82d93e3cfab01f671cc5f4a95931cfe3 for an example)
+repositoryName = mavenpattern
+
+# What the artifact should be called. These will be the "name" of the published package. (groupid:artifactid:version:qualifier).
+# The version is determined automatically from the git version (the same way the buildscript does it)
+mavenGroupId = gtmega
+mavenArtifactId = gt5u
+
 # Will update your build.gradle automatically whenever an update is available
 autoUpdateBuildScript = false
 

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -1,0 +1,51 @@
+apply plugin: "maven-publish"
+checkPropertyExists("repositoryURL")
+checkPropertyExists("repositoryName")
+checkPropertyExists("mavenGroupId")
+checkPropertyExists("mavenArtifactId")
+
+def getMavenSettingsCredentials = {
+    String userHome = System.getProperty( "user.home" );
+    File mavenSettings = new File(userHome, ".m2/settings.xml")
+    def xmlSlurper = new XmlSlurper()
+    def output = xmlSlurper.parse(mavenSettings)
+    return output."servers"."server"
+}
+
+def getCredentials = {
+    def entries = getMavenSettingsCredentials()
+    for (entry in entries) {
+        if ( entry."id".text() == repositoryName ) {
+            return [username: entry.username.text(), password: entry.password.text()]
+        }
+    }
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifact source: jar
+            artifact source: sourcesJar, classifier: "src"
+            artifact source: devJar, classifier: "dev"
+            if (apiPackage) {
+                artifact source: apiJar, classifier: "api"
+            }
+
+            groupId = mavenGroupId
+            artifactId = mavenArtifactId
+            version = project.version
+        }
+    }
+
+    repositories {
+        maven {
+            name = repositoryName
+            url = repositoryURL
+            def creds = getCredentials()
+            credentials {
+                username = creds == null ? "none" : creds.username
+                password = creds == null ? "none" : creds.password
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is the first in a multi-repo project that makes all public gtmega mods easily publishable to a proper maven repository instead of always relying on jitpack to do the builds for dependencies.