### PR TITLE
Update buildscript

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1641429628falsepattern
+//version: 1641429628falsepattern4
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -32,7 +32,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.5'
+        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.6'
     }
 }
 
@@ -88,6 +88,8 @@ checkPropertyExists("containsMixinsAndOrCoreModOnly")
 checkPropertyExists("usesShadowedDependencies")
 checkPropertyExists("developmentEnvironmentUserName")
 
+//Properties added in fork
+checkPropertyExists("skipBuildScriptUpdateCheck")
 checkPropertyExists("repositoryURL")
 checkPropertyExists("repositoryName")
 checkPropertyExists("mavenGroupId")
@@ -158,7 +160,7 @@ configurations.all {
 'git config core.fileMode false'.execute()
 // Pulls version from git tag
 try {
-    version = gitVersion() + "-mc" + minecraftVersion
+    version = gitVersion()
 }
 catch (Exception e) {
     throw new IllegalStateException("This mod must be version controlled by Git AND the repository must provide at least one tag!");
@@ -171,6 +173,7 @@ if(project.hasProperty("customArchiveBaseName") && customArchiveBaseName) {
 else {
     archivesBaseName = modId
 }
+archivesBaseName += "-mc" + minecraftVersion
 
 minecraft {
     version = minecraftVersion + "-" + forgeVersion + "-" + minecraftVersion
@@ -190,6 +193,33 @@ minecraft {
         if(gradleTokenGroupName) {
             replace gradleTokenGroupName, modGroup
         }
+    }
+
+    def arguments = []
+    def jvmArguments = []
+
+    if(usesMixins.toBoolean()) {
+        arguments += [
+                "--mods=../build/libs/$modId-${version}.jar",
+                "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
+        ]
+        jvmArguments += [
+                "-Dmixin.debug=true", "-Dmixin.debug.countInjections=true", "-Dmixin.debug.verbose=true", "-Dmixin.debug.export=true"
+        ]
+    }
+
+    clientRunConfig {
+        args(arguments)
+        jvmArgs(jvmArguments)
+
+        if(developmentEnvironmentUserName) {
+            args("--username", developmentEnvironmentUserName)
+        }
+    }
+
+    serverRunConfig {
+        args(arguments)
+        jvmArgs(jvmArguments)
     }
 }
 
@@ -319,39 +349,6 @@ afterEvaluate {
             ]
         }
     }
-}
-
-runClient {
-    def arguments = []
-
-    if(usesMixins.toBoolean()) {
-        arguments += [
-                "--mods=../build/libs/$modId-${version}.jar",
-                "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
-        ]
-    }
-
-    if(developmentEnvironmentUserName) {
-        arguments += [
-                "--username",
-                developmentEnvironmentUserName
-        ]
-    }
-
-    args(arguments)
-}
-
-runServer {
-    def arguments = []
-
-    if (usesMixins.toBoolean()) {
-        arguments += [
-                "--mods=../build/libs/$modId-${version}.jar",
-                "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
-        ]
-    }
-
-    args(arguments)
 }
 
 tasks.withType(JavaExec).configureEach {
@@ -527,7 +524,7 @@ publishing {
             }
 
             groupId = mavenGroupId
-            artifactId = mavenArtifactId
+            artifactId = mavenArtifactId + "-mc" + minecraftVersion
             version = gitVersion()
         }
     }
@@ -554,7 +551,7 @@ task updateBuildScript {
     }
 }
 
-if (isNewBuildScriptVersionAvailable(projectDir.toString())) {
+if (!skipBuildScriptUpdateCheck.toBoolean() && isNewBuildScriptVersionAvailable(projectDir.toString())) {
     if (autoUpdateBuildScript.toBoolean()) {
         performBuildScriptUpdate(projectDir.toString())
     } else {

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,13 +20,16 @@ repositoryURL = https://gtmega.falsepattern.com/
 # (see https://gist.github.com/FalsePattern/82d93e3cfab01f671cc5f4a95931cfe3 for an example)
 repositoryName = mavenpattern
 
-# What the artifact should be called. These will be the "name" of the published package. (groupid:artifactid:version:qualifier).
-# The version is determined automatically from the git version (the same way the buildscript does it)
+# What the artifact should be called. These will be the "name" of the published package, suffixed with the minecraft version with a -mc prefix (groupid:artifactid-mcminecraftVersion:version:qualifier).
+# For instance, the default values this example ships with would turn into com.myname:mymodid-mc1.7.10:version
+# The version is determined automatically from the git version.
 mavenGroupId = gtmega
 mavenArtifactId = gt5u
 
 # Will update your build.gradle automatically whenever an update is available
 autoUpdateBuildScript = false
+# Disable checking of buildscript updates.
+skipBuildScriptUpdateCheck = false
 
 minecraftVersion = 1.7.10
 forgeVersion = 10.13.4.1614


### PR DESCRIPTION
Changes:
- Updated ForgeGradle, better mixin debugging experience in runClient/runServer
- Option to disable buildscript update checking on every gradle invocation. Useful for speeding up development
- Normalized artifact/jar naming (-mc1.7.10 suffix after artifactId/modid in jar name)